### PR TITLE
do not hide raid profiles menu page

### DIFF
--- a/AzeriteUI/front-end/stylesheet.lua
+++ b/AzeriteUI/front-end/stylesheet.lua
@@ -775,7 +775,6 @@ local Core = {
 	},
 	DisableUIMenuPages = {
 		{ ID = 5, Name = "InterfaceOptionsActionBarsPanel" },
-		{ ID = 10, Name = "CompactUnitFrameProfiles" }
 	},
 	UseEasySwitch = true, 
 		EasySwitch = {


### PR DESCRIPTION
If UnitFrameRaid allowBlizzard is enabled, this fixes the compact raidframes' profile selection on load (it uses an empty profile otherwise, and one must be selected manually through the group tools frame).

This could probably be conditional on allowBlizzard, but I couldn't figure out how to access that setting from stylesheet.lua.

Additionally I have a local hack, not submitted here, which unconditionally removes the code from `back-end/libraries/blizzard.lua UIWidgets["UnitFrameRaid"]` - since I'm using the default raid frames I obviously don't want to unregister any event handlers related to them. I mention it since that code should probably(?) also be conditional on allowBlizzard (or enableRaidFrames, or both)