### PR TITLE
hide Divine Purpose on nameplates

### DIFF
--- a/AzeriteUI/front-end/private.lua
+++ b/AzeriteUI/front-end/private.lua
@@ -570,6 +570,7 @@ Private.GetMedia = function(name, type) return ([[Interface\AddOns\%s\media\%s.%
 -- Spammy stuff that is implicit and not really needed
 --auraUserFlags[155722] = NeverOnPlate -- Rake (just for my own testing purposes)
 auraUserFlags[204242] = NeverOnPlate -- Consecration (talent Consecrated Ground)
+auraUserFlags[223819] = NeverOnPlate -- Divine Purpose proc (talent Divine Purpose)
 
 -- NPC buffs that are completely useless
 ------------------------------------------------------------------------


### PR DESCRIPTION
Retribution paladins' Divine Purpose buff shows on the personal resource display nameplate, but it's redundant since there is another visual UI indication for the proc already (pictured below, above the player character). So hide it.
![WoWScrnShot_070719_160500](https://user-images.githubusercontent.com/167940/60769094-74869a00-a0d4-11e9-9e58-eb41e81845f8.jpg)
