### PR TITLE
simplify spellcast interruptible/not interruptible handling

### DIFF
--- a/AzeriteUI/back-end/plugins/unit_cast.lua
+++ b/AzeriteUI/back-end/plugins/unit_cast.lua
@@ -338,38 +338,8 @@ Update = function(self, event, unit, ...)
 
 		element:Hide()
 		
-	elseif (event == "UNIT_SPELLCAST_INTERRUPTIBLE") then	
-		if element.casting then
-			local name, text, texture, startTime, endTime, isTradeSkill, castID, notInterruptible, spellID = UnitCastingInfo(unit)
-			if name then
-				element.interrupt = notInterruptible
-			end
-		elseif element.channeling then
-			local name, text, texture, startTime, endTime, isTradeSkill, castID, notInterruptible, spellID = UnitCastingInfo(unit)
-			if name then
-				element.interrupt = notInterruptible
-			end
-		end
-		if element.Shield then 
-			if element.interrupt and not UnitIsUnit(unit ,"player") then
-				element.Shield:Show()
-			else
-				element.Shield:Hide()
-			end
-		end
-	
-	elseif (event == "UNIT_SPELLCAST_NOT_INTERRUPTIBLE") then	
-		if element.casting then
-			local name, text, texture, startTime, endTime, isTradeSkill, castID, notInterruptible, spellID = UnitCastingInfo(unit)
-			if name then
-				element.interrupt = notInterruptible
-			end
-		elseif element.channeling then
-			local name, text, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID = UnitChannelInfo(unit)
-			if name then
-				element.interrupt = notInterruptible
-			end
-		end
+	elseif (event == "UNIT_SPELLCAST_INTERRUPTIBLE" or event == "UNIT_SPELLCAST_NOT_INTERRUPTIBLE") then
+		element.interruptible = (event == "UNIT_SPELLCAST_INTERRUPTIBLE")
 		if element.Shield then 
 			if element.interrupt and not UnitIsUnit(unit ,"player") then
 				element.Shield:Show()


### PR DESCRIPTION
Unfortunately I don't have a good way to repro this, so this change is pretty much untested, but: I noticed on Stormwall Blockade that the castbar for Tidal Empowerment never changed from its not-interruptible look to interruptible even though it was possible to interrupt the cast. I suspect that UnitCastingInfo does not return the correct information when the event fires, so this diff takes a page out of Blizzard's casting bar code and toggles the interruptible state of the frame based on the event, not on UnitCastingInfo.